### PR TITLE
Fix error on GenologicsAPIImpl.create method when try create new sample .

### DIFF
--- a/src/main/java/org/cruk/genologics/api/impl/GenologicsAPIImpl.java
+++ b/src/main/java/org/cruk/genologics/api/impl/GenologicsAPIImpl.java
@@ -1112,7 +1112,7 @@ public class GenologicsAPIImpl implements GenologicsAPI
         Class<?> entityClass = entity.getClass();
         GenologicsEntity entityAnno = checkEntityAnnotated(entity.getClass());
 
-        if (!entityAnno.creatable())
+        if (!entityAnno.creatable() && void.class.equals(entityAnno.creationClass())) 
         {
             throw new GenologicsUpdateException(getShortClassName(entityClass) + " cannot be created.");
         }


### PR DESCRIPTION
Sample is annotated as no creatable but has specific class (SampleCreation) used in creation.

org.cruk.genologics.api.GenologicsUpdateException: Sample cannot be created.
 at org.cruk.genologics.api.impl.GenologicsAPIImpl.create(GenologicsAPIImpl.java:1117)
